### PR TITLE
Default configuration parameters are not overridden

### DIFF
--- a/lib/engtagger.rb
+++ b/lib/engtagger.rb
@@ -183,7 +183,7 @@ class EngTagger
     @conf[:debug] = false
     # assuming that we start analyzing from the beginninga new sentence...
     @conf[:current_tag] = 'pp' 
-    @conf.merge(params) if params
+    @conf.merge!(params)
     unless File.exists?(@conf[:word_path]) and File.exists?(@conf[:tag_path])
       print "Couldn't locate POS lexicon, creating a new one" if @conf[:debug]
       @@hmm = Hash.new

--- a/test/test_engtagger.rb
+++ b/test/test_engtagger.rb
@@ -191,6 +191,11 @@ EOD
     text = ""
     assert(!@tagger.valid_text(text))
   end
+
+  def test_override_default_params
+    @tagger = EngTagger.new(:longest_noun_phrase => 3)
+    assert_equal 3, @tagger.conf[:longest_noun_phrase]
+  end
 end
 
 # Number of errors detected: 24


### PR DESCRIPTION
Passing in parameters to `EngTagger.new` was having no effect.
