### PR TITLE
hotfix EngTagger#get_readable fails to parse words wrapped in <>

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ of this Ruby library
 
 * Carlos Ramirez III
 * Phil London
-* Bazay (Baron Bloomer)
+* [bazay](https://github.com/bazay) (Baron Bloomer)
 
 ### Acknowledgement
 

--- a/lib/engtagger.rb
+++ b/lib/engtagger.rb
@@ -260,10 +260,9 @@ class EngTagger
   def get_readable(text, verbose = false)
     return nil unless valid_text(text)
     tagged = add_tags(text, verbose)
-    tagged = tagged.gsub(/<\w+>([^<]+)<\/(\w+)>/o) do
+    tagged = tagged.gsub(/<\w+>([^<]+|[<\w>]+)<\/(\w+)>/o) do
       $1 + '/' + $2.upcase
     end
-    return tagged
   end
 
   # Return an array of sentences (without POS tags) from a text.

--- a/lib/engtagger/version.rb
+++ b/lib/engtagger/version.rb
@@ -1,3 +1,3 @@
 module EngTagger
-  VERSION = "0.2.1"
+  VERSION = '0.2.2'.freeze
 end

--- a/test/test_engtagger.rb
+++ b/test/test_engtagger.rb
@@ -143,7 +143,13 @@ EOD
   def test_get_readable
     test = "I woke up to the sound of pouring rain."
     result = @tagger.get_readable(test)
-    assert(String, result)
+    expected_result = "I/PRP woke/VBD up/RB to/TO the/DET sound/NN of/IN pouring/VBG rain/NN ./PP"
+    assert_equal(expected_result, result)
+
+    test = "I woke up with a <bad> word."
+    result = @tagger.get_readable(test)
+    expected_result = "I/PRP woke/VBD up/RB with/IN a/DET <bad>/NNP word/NN ./PP"
+    assert_equal(expected_result, result)
   end
 
   def test_get_sentences


### PR DESCRIPTION
Solves: https://github.com/yohasebe/engtagger/issues/12 (ISSUE)