### PR TITLE
Fix for using gem with Rails

### DIFF
--- a/lib/engtagger.rb
+++ b/lib/engtagger.rb
@@ -1,9 +1,8 @@
 #!/usr/bin/env ruby
 # -*- coding: utf-8 -*-
 
-$LOAD_PATH << File.join(File.dirname(__FILE__), 'engtagger')
 require 'rubygems'
-require 'porter'
+require 'engtagger/porter'
 require 'lru_redux'
 
 module BoundedSpaceMemoizable


### PR DESCRIPTION
Removed **$LOAD_PATH** variable from using in code.

I spent 3 days to find and fix this bug 🔮 

Using this global variable **$LOAD_PATH** broke the `require` in our Rails app (rails 6.1.6):

![Screen Shot 2022-08-03 at 13 42 16](https://user-images.githubusercontent.com/8033090/183008670-85811a24-52b1-4f41-894f-b735679a03c6.png)

<img width="526" alt="Screen Shot 2022-08-03 at 16 11 31" src="https://user-images.githubusercontent.com/8033090/183008724-273027e5-8e78-4a8b-a615-536bf3021b84.png">

<img width="457" alt="Screen Shot 2022-08-03 at 23 42 34" src="https://user-images.githubusercontent.com/8033090/183008743-6e58a1ae-2dcc-4509-8641-cee0c59144e5.png">

Thank you for your work!

