### PR TITLE
Uninstall lru redux and install sin lru redux

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "lru_redux"
+gem "sin_lru_redux"

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "rake"
+gem "test-unit"
 gem "sin_lru_redux"

--- a/engtagger.gemspec
+++ b/engtagger.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.name          = "engtagger"
   gem.require_paths = ["lib"]
   gem.version       = EngTagger::VERSION
-  gem.add_dependency "lru_redux"
+  gem.add_dependency "sin_lru_redux"
 end

--- a/lib/engtagger.rb
+++ b/lib/engtagger.rb
@@ -12,7 +12,7 @@ module BoundedSpaceMemoizable
     alias_method "__memoized__#{method}", method
     module_eval <<-MODEV
       def #{method}(*a)
-        @__memoized_#{method}_cache ||= LruRedux::Cache.new(#{max_cache_size})
+        @__memoized_#{method}_cache ||= LruRedux::Cache.new(#{max_cache_size}, true)
         @__memoized_#{method}_cache[a] ||= __memoized__#{method}(*a)
       end
     MODEV


### PR DESCRIPTION
## What's changed

- Uninstall `lru_redux` and install `sin_lru_redux` because `lru_redux` has not been maintained for over 10 years
- Set ignore_nil argument to true for saving memory
- Fix not being able to run tests
